### PR TITLE
Remove incorrect characters from pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,9 +116,9 @@
       		<groupId>org.apache.maven.plugins</groupId>
        		<artifactId>maven-javadoc-plugin</artifactId>
        		<version>2.9.1</version>
-       		<configuration> ^M
-       			<source>8</source> ^M
-       		</configuration>^M
+       		<configuration>
+       			<source>8</source>
+       		</configuration>
        		<executions>
          		<execution>
            		<id>attach-javadocs</id>


### PR DESCRIPTION
I saw your android PR with the nice side-effect that it can be used with java version < 8. Unfortunately there were a few meta characters in the pom file preventing travis to build it. In this PR they are removed, so that you can hopefully get your PR integrated.